### PR TITLE
Reduced network traffic

### DIFF
--- a/data/default_cluster.json
+++ b/data/default_cluster.json
@@ -1,3 +1,4 @@
 {
-  "controller":"localhost"
+  "controller":"localhost",
+  "max_set_size":500
 }

--- a/src/comms/requests.h
+++ b/src/comms/requests.h
@@ -117,15 +117,6 @@ struct MarshalledClusterSet {
 
     buf.AppendBuffer(reinterpret_cast<char*>(&idx), sizeof(uint32_t));
   }
-
-  MarshalledClusterSet& operator=(const MarshalledClusterSet& other)  {
-    buf.AppendBuffer(other.buf.data(), other.TotalSize());
-    return *this;
-  } 
-  
-  MarshalledClusterSet(const MarshalledClusterSet& other) {
-    buf.AppendBuffer(other.buf.data(), other.TotalSize());
-  }
   
   MarshalledClusterSet(MarshalledResponse& response)
       : buf(agd::Buffer(response.msg.size() - sizeof(uint32_t), 128)) {

--- a/src/comms/requests.h
+++ b/src/comms/requests.h
@@ -3,7 +3,7 @@
 #include "src/agd/buffer.h"
 #include "zmq.hpp"
 
-enum RequestType { Batch = 0, Partial };
+enum RequestType { Batch = 0, Partial, LargePartial };
 
 struct __attribute__((packed)) BatchRequestHeader {
   int id;
@@ -118,6 +118,15 @@ struct MarshalledClusterSet {
     buf.AppendBuffer(reinterpret_cast<char*>(&idx), sizeof(uint32_t));
   }
 
+  MarshalledClusterSet& operator=(const MarshalledClusterSet& other)  {
+    buf.AppendBuffer(other.buf.data(), other.TotalSize());
+    return *this;
+  } 
+  
+  MarshalledClusterSet(const MarshalledClusterSet& other) {
+    buf.AppendBuffer(other.buf.data(), other.TotalSize());
+  }
+  
   MarshalledClusterSet(MarshalledResponse& response)
       : buf(agd::Buffer(response.msg.size() - sizeof(uint32_t), 128)) {
     // a response buffer is an int id and a marshalled clusterset
@@ -199,6 +208,18 @@ struct MarshalledRequest {
     buf.AppendBuffer(set.buf.data(), set.buf.size());
     assert(buf.size() == total + sizeof(PartialRequestHeader));
   }
+
+  //Does not have a clusterset, but is still large :P
+  void CreateLargePartialRequest(int id, MarshalledClusterView cluster) {
+    buf.reserve(cluster.TotalSize() + sizeof(PartialRequestHeader));
+    PartialRequestHeader h;
+    h.id = id;
+    h.type = RequestType::LargePartial;
+    buf.AppendBuffer(reinterpret_cast<char*>(&h), sizeof(PartialRequestHeader));
+    buf.AppendBuffer(cluster.data, cluster.TotalSize());
+    assert(buf.size() == cluster.TotalSize() + sizeof(PartialRequestHeader));  
+  }
+
   agd::Buffer buf;
 };
 
@@ -232,6 +253,12 @@ struct MarshalledRequestView {
 
     const char* cluster_set_ptr = cluster_ptr + sz;
     *cluster_set = MarshalledClusterSetView(cluster_set_ptr);
+  }
+
+  // for Large Partial requests
+  void Cluster(MarshalledClusterView* cluster)  {
+    const char* cluster_ptr = data + sizeof(PartialRequestHeader);
+    *cluster = MarshalledClusterView(cluster_ptr);
   }
 
   // for batch

--- a/src/comms/requests.h
+++ b/src/comms/requests.h
@@ -117,7 +117,7 @@ struct MarshalledClusterSet {
 
     buf.AppendBuffer(reinterpret_cast<char*>(&idx), sizeof(uint32_t));
   }
-  
+
   MarshalledClusterSet(MarshalledResponse& response)
       : buf(agd::Buffer(response.msg.size() - sizeof(uint32_t), 128)) {
     // a response buffer is an int id and a marshalled clusterset
@@ -200,7 +200,7 @@ struct MarshalledRequest {
     assert(buf.size() == total + sizeof(PartialRequestHeader));
   }
 
-  //Does not have a clusterset, but is still large :P
+  // Does not have a clusterset, but is still large :P
   void CreateLargePartialRequest(int id, MarshalledClusterView cluster) {
     buf.reserve(cluster.TotalSize() + sizeof(PartialRequestHeader));
     PartialRequestHeader h;
@@ -208,7 +208,7 @@ struct MarshalledRequest {
     h.type = RequestType::LargePartial;
     buf.AppendBuffer(reinterpret_cast<char*>(&h), sizeof(PartialRequestHeader));
     buf.AppendBuffer(cluster.data, cluster.TotalSize());
-    assert(buf.size() == cluster.TotalSize() + sizeof(PartialRequestHeader));  
+    assert(buf.size() == cluster.TotalSize() + sizeof(PartialRequestHeader));
   }
 
   agd::Buffer buf;
@@ -247,7 +247,7 @@ struct MarshalledRequestView {
   }
 
   // for Large Partial requests
-  void Cluster(MarshalledClusterView* cluster)  {
+  void Cluster(MarshalledClusterView* cluster) {
     const char* cluster_ptr = data + sizeof(PartialRequestHeader);
     *cluster = MarshalledClusterView(cluster_ptr);
   }

--- a/src/dist/BUILD
+++ b/src/dist/BUILD
@@ -1,23 +1,29 @@
 
 cc_library(
-    name = "dist_lib",
-    srcs = glob([ "*.cc", "*.h" ], exclude = ["dist_cluster.cc"]),
-    linkopts =
-        [ "-L/usr/local/lib", "-L/cluster/apps/zmq/4.3.1/x86_64/lib", "-lzmq" ],
-    copts =
-        [
-          "-std=c++14", "-I/usr/local/include", "-L/usr/local/lib",
-          "-L/cluster/apps/zmq/4.3.1/x86_64/lib"
-        ],
-    deps =
-        [
-          "@com_google_absl//absl/container:node_hash_map",
-          "@com_google_absl//absl/container:flat_hash_set",
-          "@com_google_absl//absl/strings", "@zmq//:zmq-cpp",
-          "//src/common:common", "//src/comms:comms"
-        ])
+  name = "dist_lib",
+  srcs = glob([ "*.cc", "*.h" ], exclude = ["dist_cluster.cc"]),
+  linkopts =
+      [ "-L/usr/local/lib", "-L/cluster/apps/zmq/4.3.1/x86_64/lib", "-lzmq" ],
+  copts =
+      [
+        "-std=c++14", "-I/usr/local/include", "-L/usr/local/lib",
+        "-L/cluster/apps/zmq/4.3.1/x86_64/lib"
+      ],
+  deps =
+      [
+        "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/strings", "@zmq//:zmq-cpp",
+        "//src/common:common", "//src/comms:comms"
+      ]
+)
 
-    cc_binary(name = "dist_cluster", srcs = glob(["dist_cluster.cc"]),
-              linkopts = [ "-L/usr/local/lib", "-lzmq" ],
-              copts = [ "-I/usr/local/include", "-L/usr/local/lib" ],
-              deps = [ "@args//:args", ":dist_lib" ])
+cc_binary(
+  name = "dist_cluster", srcs = glob(["dist_cluster.cc"]),
+  linkopts = [ "-L/usr/local/lib", "-lzmq" ],
+  copts = [ "-I/usr/local/include", "-L/usr/local/lib" ],
+  deps = [ 
+    "@args//:args", 
+    ":dist_lib" 
+    ]
+)

--- a/src/dist/BUILD
+++ b/src/dist/BUILD
@@ -1,26 +1,23 @@
 
 cc_library(
-  name = "dist_lib",
-  srcs = glob(["*.cc", "*.h"], exclude=["dist_cluster.cc"]),
-  linkopts = ["-L/usr/local/lib", "-L/cluster/apps/zmq/4.3.1/x86_64/lib", "-lzmq"],
-  copts = ["-std=c++14", "-I/usr/local/include", "-L/usr/local/lib", "-L/cluster/apps/zmq/4.3.1/x86_64/lib"],
-  deps = [
+    name = "dist_lib",
+    srcs = glob([ "*.cc", "*.h" ], exclude = ["dist_cluster.cc"]),
+    linkopts =
+        [ "-L/usr/local/lib", "-L/cluster/apps/zmq/4.3.1/x86_64/lib", "-lzmq" ],
+    copts =
+        [
+          "-std=c++14", "-I/usr/local/include", "-L/usr/local/lib",
+          "-L/cluster/apps/zmq/4.3.1/x86_64/lib"
+        ],
+    deps =
+        [
           "@com_google_absl//absl/container:node_hash_map",
           "@com_google_absl//absl/container:flat_hash_set",
-          "@com_google_absl//absl/strings",
-          "@zmq//:zmq-cpp",
-          "//src/common:common",
-          "//src/comms:comms"
-         ]
-)
+          "@com_google_absl//absl/strings", "@zmq//:zmq-cpp",
+          "//src/common:common", "//src/comms:comms"
+        ])
 
-cc_binary(
-  name = "dist_cluster",
-  srcs = glob(["dist_cluster.cc"]),
-  linkopts = ["-L/usr/local/lib", "-lzmq"],
-  copts = ["-I/usr/local/include", "-L/usr/local/lib"],
-  deps = [
-          "@args//:args",
-          ":dist_lib"
-         ]
-)
+    cc_binary(name = "dist_cluster", srcs = glob(["dist_cluster.cc"]),
+              linkopts = [ "-L/usr/local/lib", "-lzmq" ],
+              copts = [ "-I/usr/local/include", "-L/usr/local/lib" ],
+              deps = [ "@args//:args", ":dist_lib" ])

--- a/src/dist/README.md
+++ b/src/dist/README.md
@@ -1,2 +1,1 @@
-# Distributed implementation
-
+#Distributed implementation

--- a/src/dist/checkpoint.h
+++ b/src/dist/checkpoint.h
@@ -9,10 +9,12 @@
 // file is a blob
 // just a dump of serialized clusterSets in the sets to merge queue
 
-agd::Status WriteCheckpointFile(const absl::string_view path,
+agd::Status WriteCheckpointFile(
+    const absl::string_view path,
     const std::unique_ptr<ConcurrentQueue<MarshalledClusterSet>>& queue);
 
-agd::Status LoadCheckpointFile(const absl::string_view path,
+agd::Status LoadCheckpointFile(
+    const absl::string_view path,
     std::unique_ptr<ConcurrentQueue<MarshalledClusterSet>>& queue);
 
 bool CheckpointFileExists(const absl::string_view path);

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -205,7 +205,6 @@ agd::Status Controller::Run(const Params& params,
 
     while (run_) {
       if (!request_queue_->pop(merge_request)) {
-        // cout << "req qt -- Stuck here.\n";
         continue;
       }
 
@@ -228,44 +227,46 @@ agd::Status Controller::Run(const Params& params,
     cout << "Work queue thread ending. Total sent: " << total_sent << "\n";
   });
 
-  // large_partial_merge_thread_ = thread([this](){
-  //   //receive requests from worker and send them cluster sets
+  large_partial_merge_thread_ = thread([this](){
+    //receive requests from worker and send them cluster sets
     
-  //   auto free_func = [](void* data, void* hint) {
-  //     delete [] reinterpret_cast<char*>(data);
-  //   };
+    auto free_func = [](void* data, void* hint) {
+      delete [] reinterpret_cast<char*>(data);
+    };
     
-  //   while(run_) {
-  //     zmq::message_t message;
-  //     zmq_large_partial_merge_socket_->recv(&message);
-  //     //extract the id
-  //     int id = *reinterpret_cast<int*>(message.data());
-  //     cout << "Got set request with id [" << id << "]\n";
+    while(run_) {
+      zmq::message_t message;
+      zmq_large_partial_merge_socket_->recv(&message);
+      //extract the id
+      int id = *reinterpret_cast<int*>(message.data());
+      cout << "Got set request with id [" << id << "]\n";
       
-  //     //search in partial merge map
-  //     PartialMergeItem* partial_item;
-  //     {
-  //       absl::MutexLock l(&mu_);
-  //       auto partial_it = partial_merge_map_.find(id);
-  //       if (partial_it == partial_merge_map_.end()) {
-  //         cout << "the set with " << id << " is not in the map \n";
-  //         exit(0);
-  //       }
-  //       partial_item = &partial_it->second;
+      //search in partial merge map
+      PartialMergeItem* partial_item;
+      {
+        absl::MutexLock l(&mu_);
+        auto partial_it = partial_merge_map_.find(id);
+        if (partial_it == partial_merge_map_.end()) {
+          cout << "the set with " << id << " is not in the map \n";
+          exit(0);
+        }
+        partial_item = &partial_it->second;
+        //cout << "Some data --> " << partial_item->buf.size() << std::endl;
         
-  //       //creating a copy since zmq takes ownership without creating a copy
-  //       MarshalledClusterSet set2 = partial_item->set2;
-  //       auto size = set2.TotalSize();
-  //       zmq::message_t msg(set2.buf.release_raw(), size, free_func, NULL);
-  //       bool success = zmq_large_partial_merge_socket_->send(std::move(msg));  
-  //       if(!success)  {
-  //         cout << "Thread failed to send cluster set over zmq!\n";
-  //       }
-  //       cout << "Set sent with id: [" << id << "]\n";
-  //     }
-  //   }
+        //creating a copy since zmq takes ownership without creating a copy
+        agd::Buffer buf;
+        buf.AppendBuffer(partial_item->buf.data(), partial_item->buf.size());
+        zmq::message_t msg(buf.release_raw(), buf.size(), free_func, NULL);
+        cout << "Size of message = " << msg.size() << std::endl;
+        bool success = zmq_large_partial_merge_socket_->send(std::move(msg));  
+        if(!success)  {
+          cout << "Thread failed to send cluster set over zmq!\n";
+        }
+        cout << "Set sent with id: [" << id << "] \n";
+      }
+    }
 
-  // });
+  });
 
   int total_received = 0;
   response_queue_thread_ = thread([this, &total_received]() {
@@ -528,6 +529,15 @@ agd::Status Controller::Run(const Params& params,
       // all clusters in sets[1]
       item.num_expected = sets[0].NumClusters();
       item.partial_set.Init(sets[1]);
+      
+      bool isLarge = false;
+      //add to params
+      if(sets[1].TotalSize() > 500) {
+        isLarge = true;
+        cout << "Its a large partial set. Id = " << outstanding_merges_ << "\n";
+        item.buf.AppendBuffer(sets[1].buf.data(), sets[1].buf.size());
+      }
+      
       {
         absl::MutexLock l(&mu_);
         // cout << "pushing id " << outstanding_merges_ << " to map\n";
@@ -539,14 +549,7 @@ agd::Status Controller::Run(const Params& params,
       // cout << "pushing id " << outstanding_merges_ << "\n";
       uint32_t total_cluster = sets[0].NumClusters();
       uint32_t i = 0;
-      bool isLarge = false;
-      //add to params
-      // if(sets[1].TotalSize() > 500) {
-      //   isLarge = true;
-      //   //copies the set
-      //   item.set2 = MarshalledClusterSet(sets[1]);
-      //   cout << "Its a large partial set. Id = " << outstanding_merges_ << "\n";
-      // }
+      
       while (sets[0].NextCluster(&cluster)) {
         i++;
         MarshalledRequest request;
@@ -558,7 +561,7 @@ agd::Status Controller::Run(const Params& params,
         // cout << "pushing partial request with " <<
         // partial_request->set().clusters_size() << " clusters in set and ID: "
         // << request.id() << "\n";
-        cout << "Pushing partial merge request " << "\n";
+        //cout << "Pushing partial merge request " << "\n";
         request_queue_->push(std::move(request));
       }
       outstanding_requests++;

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -268,7 +268,8 @@ agd::Status Controller::Run(const Params& params,
 
         // creating a copy since zmq takes ownership without creating a copy
         agd::Buffer buf;
-        buf.AppendBuffer(partial_item->buf.data(), partial_item->buf.size());
+        buf.AppendBuffer(partial_item->marshalled_set_buf.data(),
+                         partial_item->marshalled_set_buf.size());
         zmq::message_t msg(buf.release_raw(), buf.size(), free_func, NULL);
         // cout << "Size of message = " << msg.size() << std::endl;
         bool success = zmq_set_request_socket_->send(std::move(msg));
@@ -550,7 +551,8 @@ agd::Status Controller::Run(const Params& params,
         isLarge = true;
         // cout << "Its a large partial set. Id = " << outstanding_merges_ <<
         // "\n";
-        item.buf.AppendBuffer(sets[1].buf.data(), sets[1].buf.size());
+        item.marshalled_set_buf.AppendBuffer(sets[1].buf.data(),
+                                             sets[1].buf.size());
       }
 
       {

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -626,6 +626,7 @@ agd::Status Controller::Run(const Params& params,
   request_queue_thread_.join();
   response_queue_thread_.join();
   incomplete_request_queue_thread_.join();
+  //large_partial_merge_thread_.join();
 
   cout << "All threads joined.\n";
 

--- a/src/dist/controller.h
+++ b/src/dist/controller.h
@@ -89,17 +89,20 @@ class Controller {
       partial_set = std::move(other.partial_set);
       num_expected = other.num_expected;
       num_received.store(other.num_received.load());
+      buf = std::move(other.buf);
     }
     PartialMergeItem& operator=(PartialMergeItem&& other) {
       partial_set = std::move(other.partial_set);
       num_expected = other.num_expected;
       num_received.store(other.num_received.load());
+      buf = std::move(other.buf);
       return *this;
     }
     PartialMergeSet partial_set;
     uint32_t num_expected;
     std::atomic_uint_fast32_t num_received;
-    MarshalledClusterSet set2;
+    //holds the MarshalledClusterSet
+    agd::Buffer buf;
     // uint32_t original_size;
   };
 

--- a/src/dist/controller.h
+++ b/src/dist/controller.h
@@ -90,20 +90,20 @@ class Controller {
       partial_set = std::move(other.partial_set);
       num_expected = other.num_expected;
       num_received.store(other.num_received.load());
-      buf = std::move(other.buf);
+      marshalled_set_buf = std::move(other.marshalled_set_buf);
     }
     PartialMergeItem& operator=(PartialMergeItem&& other) {
       partial_set = std::move(other.partial_set);
       num_expected = other.num_expected;
       num_received.store(other.num_received.load());
-      buf = std::move(other.buf);
+      marshalled_set_buf = std::move(other.marshalled_set_buf);
       return *this;
     }
     PartialMergeSet partial_set;
     uint32_t num_expected;
     std::atomic_uint_fast32_t num_received;
     // holds the MarshalledClusterSet responding to set requests
-    agd::Buffer buf;
+    agd::Buffer marshalled_set_buf = agd::Buffer(2048, 512);
     // uint32_t original_size;
   };
 

--- a/src/dist/controller.h
+++ b/src/dist/controller.h
@@ -25,6 +25,7 @@ class Controller {
     int request_queue_port;
     int response_queue_port;
     int incomplete_request_queue_port;
+    int large_partial_merge_port;
     absl::string_view data_dir_path;
     uint32_t batch_size;
     uint32_t dup_removal_thresh;
@@ -41,9 +42,11 @@ class Controller {
   zmq::context_t context_;
   zmq::context_t context_sink_;
   zmq::context_t context_ir_sink_;  // ir stands for incomplete requests
+  zmq::context_t context_large_partial_merge_;  //pm : partial merge 
   std::unique_ptr<zmq::socket_t> zmq_recv_socket_;
   std::unique_ptr<zmq::socket_t> zmq_send_socket_;
   std::unique_ptr<zmq::socket_t> zmq_incomplete_request_socket_;
+  std::unique_ptr<zmq::socket_t> zmq_large_partial_merge_socket_;
 
   // thread reads from zmq and puts into response queue
   std::unique_ptr<ConcurrentQueue<MarshalledResponse>> response_queue_;
@@ -66,6 +69,9 @@ class Controller {
   // controller reads incomplete requests into this queue
   std::unique_ptr<ConcurrentQueue<MarshalledRequest>> incomplete_request_queue_;
   std::thread incomplete_request_queue_thread_;
+
+  // thread to send partial merge sets
+  std::thread large_partial_merge_thread_;
 
   std::vector<Sequence> sequences_;  // abs indexable sequences
 
@@ -93,6 +99,7 @@ class Controller {
     PartialMergeSet partial_set;
     uint32_t num_expected;
     std::atomic_uint_fast32_t num_received;
+    MarshalledClusterSet set2;
     // uint32_t original_size;
   };
 

--- a/src/dist/dist_cluster.cc
+++ b/src/dist/dist_cluster.cc
@@ -48,7 +48,7 @@ constexpr char cluster_config_default[] = "data/default_cluster.json";
 // captures kill signal and notifies Worker
 volatile int signal_num = 0;
 
-void my_handler(int sig) {
+void signal_notifier(int sig) {
   signal_num = sig;
   cout << "[signal_num] value changed.\n";
 }
@@ -370,8 +370,8 @@ int main(int argc, char* argv[]) {
     params.response_queue_port = response_queue_port;
     params.incomplete_request_queue_port = incomplete_request_queue_port;
     params.set_request_port = set_request_port;
-    signal(SIGUSR1, my_handler);
-    // signal(SIGINT, my_handler);
+    signal(SIGUSR1, signal_notifier);
+    // signal(SIGINT, signal_notifier);
     Status stat =
         worker.Run(params, aligner_params, datasets, (int*)&signal_num);
     if (!stat.ok()) {

--- a/src/dist/dist_cluster.cc
+++ b/src/dist/dist_cluster.cc
@@ -41,7 +41,7 @@ constexpr char cluster_config_default[] = "data/default_cluster.json";
 #define DEFAULT_RESPONSE_QUEUE_PORT 5556
 #define DEFAULT_REQUEST_QUEUE_PORT 5555
 #define DEFAULT_INCOMPLETE_REQUEST_QUEUE_PORT 5554
-#define DEFAULT_LARGE_PARTIAL_MERGE_PORT 5553
+#define DEFAULT_LARGE_PARTIAL_MERGE_PORT 5557
 
 // captures kill signal and notifies Worker
 volatile int signal_num = 0;

--- a/src/dist/dist_cluster.cc
+++ b/src/dist/dist_cluster.cc
@@ -41,6 +41,7 @@ constexpr char cluster_config_default[] = "data/default_cluster.json";
 #define DEFAULT_RESPONSE_QUEUE_PORT 5556
 #define DEFAULT_REQUEST_QUEUE_PORT 5555
 #define DEFAULT_INCOMPLETE_REQUEST_QUEUE_PORT 5554
+#define DEFAULT_LARGE_PARTIAL_MERGE_PORT 5553
 
 // captures kill signal and notifies Worker
 volatile int signal_num = 0;
@@ -159,6 +160,7 @@ int main(int argc, char* argv[]) {
   int request_queue_port;
   int response_queue_port;
   int incomplete_request_queue_port;
+  int large_partial_merge_port;
   if (server_config_file) {
     string server_config_path = args::get(server_config_file);
     std::ifstream server_config_stream(server_config_path);
@@ -206,6 +208,13 @@ int main(int argc, char* argv[]) {
     response_queue_port = DEFAULT_RESPONSE_QUEUE_PORT;  // default
   } else {
     response_queue_port = *response_queue_port_it;
+  }
+
+  auto large_partial_merge_port_it = server_config_json.find("large_partial_merge_port");
+  if (large_partial_merge_port_it == server_config_json.end()) {
+    large_partial_merge_port = DEFAULT_LARGE_PARTIAL_MERGE_PORT; //default
+  } else {
+    large_partial_merge_port = *large_partial_merge_port_it;
   }
 
   auto incomplete_request_queue_port_it =
@@ -322,6 +331,7 @@ int main(int argc, char* argv[]) {
     params.request_queue_port = request_queue_port;
     params.response_queue_port = response_queue_port;
     params.incomplete_request_queue_port = incomplete_request_queue_port;
+    params.large_partial_merge_port = large_partial_merge_port;
     params.dup_removal_thresh = dup_removal_threshold;
     params.exclude_allall = exclude_allall;
     params.checkpoint_interval = checkpoint_interval;
@@ -348,6 +358,7 @@ int main(int argc, char* argv[]) {
     params.request_queue_port = request_queue_port;
     params.response_queue_port = response_queue_port;
     params.incomplete_request_queue_port = incomplete_request_queue_port;
+    params.large_partial_merge_port = large_partial_merge_port;
     signal(SIGUSR1, my_handler);
     signal(SIGINT, my_handler);
     Status stat =

--- a/src/dist/dist_cluster.cc
+++ b/src/dist/dist_cluster.cc
@@ -360,7 +360,7 @@ int main(int argc, char* argv[]) {
     params.incomplete_request_queue_port = incomplete_request_queue_port;
     params.large_partial_merge_port = large_partial_merge_port;
     signal(SIGUSR1, my_handler);
-    signal(SIGINT, my_handler);
+    //signal(SIGINT, my_handler);
     Status stat =
         worker.Run(params, aligner_params, datasets, (int*)&signal_num);
     if (!stat.ok()) {

--- a/src/dist/merge_batch.cc
+++ b/src/dist/merge_batch.cc
@@ -3,7 +3,6 @@
 
 void MergeBatch(std::deque<ClusterSet>& sets_to_merge,
                 ProteinAligner* aligner) {
-  std::cout<<"Beginning to merge sets.\n";
   while (sets_to_merge.size() > 1) {
     // dequeue 2 sets
     // merge the sets into one
@@ -11,7 +10,7 @@ void MergeBatch(std::deque<ClusterSet>& sets_to_merge,
 
     auto& s1 = sets_to_merge[0];
     auto& s2 = sets_to_merge[1];
-
+    
     /*cout << "Merging cluster sets of size " << s1.Size()
       << " and " << s2.Size() << "\n";
     cout << "Cluster sets remaining: " << sets_.size() - 2 << "\n";*/
@@ -19,10 +18,8 @@ void MergeBatch(std::deque<ClusterSet>& sets_to_merge,
     // cout << "\nand\n";
     // s2.DebugDump();
     auto merged_set = s1.MergeClusters(s2, aligner);
-
     sets_to_merge.pop_front();
     sets_to_merge.pop_front();
     sets_to_merge.push_back(std::move(merged_set));
   };
-  std::cout << "Finished merging sets.\n"; 
 }

--- a/src/dist/merge_batch.cc
+++ b/src/dist/merge_batch.cc
@@ -10,7 +10,7 @@ void MergeBatch(std::deque<ClusterSet>& sets_to_merge,
 
     auto& s1 = sets_to_merge[0];
     auto& s2 = sets_to_merge[1];
-    
+
     /*cout << "Merging cluster sets of size " << s1.Size()
       << " and " << s2.Size() << "\n";
     cout << "Cluster sets remaining: " << sets_.size() - 2 << "\n";*/

--- a/src/dist/merge_batch.cc
+++ b/src/dist/merge_batch.cc
@@ -3,6 +3,7 @@
 
 void MergeBatch(std::deque<ClusterSet>& sets_to_merge,
                 ProteinAligner* aligner) {
+  std::cout<<"Beginning to merge sets.\n";
   while (sets_to_merge.size() > 1) {
     // dequeue 2 sets
     // merge the sets into one
@@ -23,4 +24,5 @@ void MergeBatch(std::deque<ClusterSet>& sets_to_merge,
     sets_to_merge.pop_front();
     sets_to_merge.push_back(std::move(merged_set));
   };
+  std::cout << "Finished merging sets.\n"; 
 }

--- a/src/dist/worker.h
+++ b/src/dist/worker.h
@@ -66,8 +66,8 @@ class Worker {
   bool irqt_signal_ = false;
 
   // cache for partial merge sets, buf is the buf of MarshalledClusterSet
-  std::unordered_map<int, agd::Buffer> set_map;
-  absl::Mutex mu_;  // for locking set_map
+  std::unordered_map<int, agd::Buffer> set_map_;
+  absl::Mutex mu_;  // for locking set_map_
 
   // queue to hold set requests
   std::unique_ptr<ConcurrentQueue<std::pair<int, MultiNotification*>>>

--- a/src/dist/worker.h
+++ b/src/dist/worker.h
@@ -9,6 +9,7 @@
 #include "src/comms/requests.h"
 #include "src/dataset/dataset.h"
 #include "zmq.hpp"
+#include "src/common/multi_notification.h"
 
 // interface to manage local worker
 class Worker {
@@ -64,9 +65,15 @@ class Worker {
   std::thread incomplete_request_queue_thread_;
   bool irqt_signal_ = false;
 
-  //map for large sets, buf is the buf of MarshalledClusterSet
+  //cache for partial merge sets, buf is the buf of MarshalledClusterSet
   std::unordered_map<int, agd::Buffer> set_map;
+  absl::Mutex mu_;  //for locking set_map
 
+  // queue to hold set requests
+  std::unique_ptr<ConcurrentQueue<std::pair<int, MultiNotification*>>> set_request_queue_;
+  std::thread set_request_thread_;
+  
+  
   std::vector<Sequence> sequences_;  // abs indexable sequences
 
   std::thread queue_measure_thread_;

--- a/src/dist/worker.h
+++ b/src/dist/worker.h
@@ -22,6 +22,7 @@ class Worker {
     int request_queue_port;
     int response_queue_port;
     int incomplete_request_queue_port;
+    int large_partial_merge_port;
     absl::string_view data_dir_path;
   };
 
@@ -40,6 +41,7 @@ class Worker {
   std::unique_ptr<zmq::socket_t> zmq_recv_socket_;
   std::unique_ptr<zmq::socket_t> zmq_send_socket_;
   std::unique_ptr<zmq::socket_t> zmq_incomplete_request_socket_;
+  std::unique_ptr<zmq::socket_t> zmq_large_partial_merge_socket_;
   // local input buffer
   // one thread receives zmq messages, decodes, puts work in work queue
   // all other threads do work and push to output buffer
@@ -72,4 +74,5 @@ class Worker {
   std::string response_queue_address;
   std::string request_queue_address;
   std::string incomplete_request_queue_address;
+  std::string large_partial_merge_channel_address;
 };

--- a/src/dist/worker.h
+++ b/src/dist/worker.h
@@ -64,6 +64,9 @@ class Worker {
   std::thread incomplete_request_queue_thread_;
   bool irqt_signal_ = false;
 
+  //map for large sets
+  std::unordered_map<int, MarshalledClusterSet> set_map;
+
   std::vector<Sequence> sequences_;  // abs indexable sequences
 
   std::thread queue_measure_thread_;

--- a/src/dist/worker.h
+++ b/src/dist/worker.h
@@ -72,7 +72,7 @@ class Worker {
   // queue to hold set requests
   std::unique_ptr<ConcurrentQueue<std::pair<int, MultiNotification*>>> set_request_queue_;
   std::thread set_request_thread_;
-  
+  bool srt_signal_ = false; //srq stands for set request thread
   
   std::vector<Sequence> sequences_;  // abs indexable sequences
 

--- a/src/dist/worker.h
+++ b/src/dist/worker.h
@@ -64,8 +64,8 @@ class Worker {
   std::thread incomplete_request_queue_thread_;
   bool irqt_signal_ = false;
 
-  //map for large sets
-  std::unordered_map<int, MarshalledClusterSet> set_map;
+  //map for large sets, buf is the buf of MarshalledClusterSet
+  std::unordered_map<int, agd::Buffer> set_map;
 
   std::vector<Sequence> sequences_;  // abs indexable sequences
 


### PR DESCRIPTION
**Feature description:** Large cluster sets are explicitly requested and cached by the workers. The controller does not send them along with every partial merge request.

**Parameters:** The max set size parameter for the request to be considered as `LargePartialMerge` instead of plain `PartialMerge` can be set in the config file using the field `max_set_size`.

Default is 500 B (which means all requests go as `LargePartialMerge` requests).