### PR TITLE
Splitting partial merges

### DIFF
--- a/src/agd/buffer.cc
+++ b/src/agd/buffer.cc
@@ -13,12 +13,14 @@ Buffer::Buffer(size_t initial_size, size_t extend_extra)
     : size_(0), allocation_(initial_size), extend_extra_(extend_extra) {
   // FIXME in an ideal world, allocation_ should be checked to be positive
   buf_ = std::make_unique<char[]>(allocation_);
+  num_allocs_++;
 }
 
 Status Buffer::WriteBuffer(const char* content, size_t content_size) {
   if (allocation_ < content_size) {
     allocation_ = content_size + extend_extra_;
     buf_.reset(new char[allocation_]());  // reset() -> old buf will be deleted
+    num_allocs_++;
   }
   memcpy(buf_.get(), content, content_size);
   size_ = content_size;
@@ -48,6 +50,7 @@ void Buffer::reserve(size_t capacity) {
     decltype(buf_) a = std::make_unique<char[]>(allocation_);
     memcpy(a.get(), buf_.get(), size_);
     buf_.swap(a);
+    num_allocs_++;
   }
 }
 
@@ -65,5 +68,9 @@ void Buffer::extend_size(size_t extend_size) {
 }
 
 size_t Buffer::capacity() const { return allocation_; }
+
+std::size_t Buffer::num_allocs() const {
+  return num_allocs_;
+}
 
 }  // namespace agd

--- a/src/agd/buffer.cc
+++ b/src/agd/buffer.cc
@@ -69,8 +69,6 @@ void Buffer::extend_size(size_t extend_size) {
 
 size_t Buffer::capacity() const { return allocation_; }
 
-std::size_t Buffer::num_allocs() const {
-  return num_allocs_;
-}
+std::size_t Buffer::num_allocs() const { return num_allocs_; }
 
 }  // namespace agd

--- a/src/agd/buffer.h
+++ b/src/agd/buffer.h
@@ -18,8 +18,7 @@ class Buffer : public Data {
 
   Buffer(Buffer&&) = default;
   Buffer& operator=(Buffer&&) = default;
-  Buffer(decltype(size_) initial_size = 64,
-         decltype(size_) extend_extra = 64);
+  Buffer(decltype(size_) initial_size = 64, decltype(size_) extend_extra = 64);
 
   Status WriteBuffer(const char* content, std::size_t content_size);
   Status AppendBuffer(const char* content, std::size_t content_size);

--- a/src/agd/buffer.h
+++ b/src/agd/buffer.h
@@ -9,7 +9,7 @@ namespace agd {
 class Buffer : public Data {
  private:
   std::unique_ptr<char[], std::default_delete<char[]>> buf_{nullptr};
-  std::size_t size_ = 0, allocation_ = 0, extend_extra_ = 0;
+  std::size_t size_ = 0, allocation_ = 0, extend_extra_ = 0, num_allocs_ = 0;
 
  public:
   ~Buffer() override = default;
@@ -50,5 +50,7 @@ class Buffer : public Data {
   virtual std::size_t size() const override;
   virtual char* mutable_data() override;
   std::size_t capacity() const;
+  // for diagnostics
+  std::size_t num_allocs() const;
 };
 }  // namespace agd

--- a/src/common/cluster_set.cc
+++ b/src/common/cluster_set.cc
@@ -385,6 +385,7 @@ ClusterSet ClusterSet::MergeCluster(Cluster& c_other, ProteinAligner* aligner,
   ProteinAligner::Alignment alignment;
   agd::Status s;
   bool fully_merged = false;
+  int c_other_old_nseqs = c_other.Sequences().size();
   for (auto& c : clusters_) {
     if (worker_signal_) {
       std::cout << "Breaking partial merge.\n";
@@ -449,8 +450,20 @@ ClusterSet ClusterSet::MergeCluster(Cluster& c_other, ProteinAligner* aligner,
   }
 
   // we can leave out without confusing the controller
-  if (!c_other.IsFullyMerged())
-    new_cluster_set.clusters_.push_back(std::move(c_other));
+  // adding only diffs
+  if (!c_other.IsFullyMerged()) {
+    Cluster c_standin;
+    auto seqs = c_other.Sequences();
+    auto it = seqs.begin();
+    // push only newly added sequences
+    std::advance(it, c_other_old_nseqs);
+    while (it != seqs.end()) {
+      c_standin.AddSequence(*it);
+      it++;
+    }
+    new_cluster_set.clusters_.push_back(std::move(c_standin));
+  }
+
 
   return new_cluster_set;
 }

--- a/src/common/cluster_set.cc
+++ b/src/common/cluster_set.cc
@@ -70,7 +70,7 @@ void ClusterSet::BuildMarshalledResponse(int id, int start_index, int end_index,
   agd::Buffer buf(buf_size);
   ResponseHeader rh;
   rh.id = id;
-  rh.type = RequestType::SubLargePartial;
+  rh.type = RequestType::Partial;
 
   // buf contains response header - three integers - cluster set
   buf.AppendBuffer(reinterpret_cast<char*>(&rh), sizeof(ResponseHeader));

--- a/src/common/cluster_set.cc
+++ b/src/common/cluster_set.cc
@@ -18,14 +18,16 @@ void free_func(void* data, void* hint) {
   delete[] reinterpret_cast<char*>(data);
 }
 
-void ClusterSet::BuildMarshalledResponse(int id, RequestType type, MarshalledResponse* response) {
+// type is implicit in the call, retained for future improvments
+void ClusterSet::BuildMarshalledResponse(int id, RequestType type,
+                                         MarshalledResponse* response) {
   // calculate buffer size for a single alloc
   size_t buf_size = sizeof(ResponseHeader) + sizeof(ClusterSetHeader);
   for (const auto& c : clusters_) {
     buf_size += sizeof(ClusterHeader) + c.Sequences().size() * sizeof(int);
   }
   agd::Buffer buf(buf_size);
-  
+
   ResponseHeader rh;
   rh.id = id;
   rh.type = type;
@@ -56,41 +58,43 @@ void ClusterSet::BuildMarshalledResponse(int id, RequestType type, MarshalledRes
 }
 
 // RequestType is implicit in the call
-void ClusterSet::BuildMarshalledResponse(int id, int start_index, 
-  int end_index, int cluster_index, MarshalledResponse* response) {
-    // calculate buffer size for a single alloc
-    size_t buf_size = sizeof(ResponseHeader) + 3*sizeof(int) + sizeof(ClusterSetHeader);
-    for (const auto& c : clusters_) {
-      buf_size += sizeof(ClusterHeader) + c.Sequences().size() * sizeof(int);
+void ClusterSet::BuildMarshalledResponse(int id, int start_index, int end_index,
+                                         int cluster_index,
+                                         MarshalledResponse* response) {
+  // calculate buffer size for a single alloc
+  size_t buf_size =
+      sizeof(ResponseHeader) + 3 * sizeof(int) + sizeof(ClusterSetHeader);
+  for (const auto& c : clusters_) {
+    buf_size += sizeof(ClusterHeader) + c.Sequences().size() * sizeof(int);
+  }
+  agd::Buffer buf(buf_size);
+  ResponseHeader rh;
+  rh.id = id;
+  rh.type = RequestType::SubLargePartial;
+
+  // buf contains response header - three integers - cluster set
+  buf.AppendBuffer(reinterpret_cast<char*>(&rh), sizeof(ResponseHeader));
+  buf.AppendBuffer(reinterpret_cast<char*>(&start_index), sizeof(int));
+  buf.AppendBuffer(reinterpret_cast<char*>(&end_index), sizeof(int));
+  buf.AppendBuffer(reinterpret_cast<char*>(&cluster_index), sizeof(int));
+
+  ClusterSetHeader h;
+  h.num_clusters = 0;  // set after once we know the value
+  buf.AppendBuffer(reinterpret_cast<char*>(&h), sizeof(ClusterSetHeader));
+
+  for (const auto& c : clusters_) {
+    // keep the fully merged for controller to remove
+    ClusterHeader ch;
+    ch.fully_merged = c.IsFullyMerged();
+    ch.num_seqs = c.Sequences().size();
+    buf.AppendBuffer(reinterpret_cast<char*>(&ch), sizeof(ClusterHeader));
+    for (const auto& s : c.Sequences()) {
+      uint32_t i = s.ID();
+      buf.AppendBuffer(reinterpret_cast<char*>(&i), sizeof(int));
     }
-    agd::Buffer buf(buf_size);
-    ResponseHeader rh;
-    rh.id = id;
-    rh.type = RequestType::SubLargePartial;
-
-    // buf contains response header - three integers - cluster set
-    buf.AppendBuffer(reinterpret_cast<char*>(&rh), sizeof(ResponseHeader));
-    buf.AppendBuffer(reinterpret_cast<char*>(&start_index), sizeof(int));
-    buf.AppendBuffer(reinterpret_cast<char*>(&end_index), sizeof(int));
-    buf.AppendBuffer(reinterpret_cast<char*>(&cluster_index), sizeof(int));
-
-    ClusterSetHeader h;
-    h.num_clusters = 0;  // set after once we know the value
-    buf.AppendBuffer(reinterpret_cast<char*>(&h), sizeof(ClusterSetHeader));
-
-    for (const auto& c : clusters_) {
-      // keep the fully merged for controller to remove
-      ClusterHeader ch;
-      ch.fully_merged = c.IsFullyMerged();
-      ch.num_seqs = c.Sequences().size();
-      buf.AppendBuffer(reinterpret_cast<char*>(&ch), sizeof(ClusterHeader));
-      for (const auto& s : c.Sequences()) {
-        uint32_t i = s.ID();
-        buf.AppendBuffer(reinterpret_cast<char*>(&i), sizeof(int));
-      }
   }
 
-  char* data = buf.mutable_data() + sizeof(ResponseHeader) + 3*sizeof(int);
+  char* data = buf.mutable_data() + sizeof(ResponseHeader) + 3 * sizeof(int);
   ClusterSetHeader* hp = reinterpret_cast<ClusterSetHeader*>(data);
   hp->num_clusters = clusters_.size();
   // hand the buf pointer to the message
@@ -120,21 +124,22 @@ ClusterSet::ClusterSet(MarshalledClusterSet& marshalled_set,
   }
 }
 
-ClusterSet::ClusterSet(MarshalledClusterSetView& marshalled_set, vector<size_t>& set_offsets, 
-  int start_index, int end_index, const std::vector<Sequence>& sequences) {
-    MarshalledClusterView cluster;
-    for (int i = start_index; i <= end_index; i++) {
-      marshalled_set.ClusterAtOffset(&cluster, set_offsets[i]);
-      Cluster c(sequences[cluster.SeqIndex(0)]);
-      uint32_t num_seqs = cluster.NumSeqs();
-      for (size_t seq_i = 1; seq_i < num_seqs; seq_i++) {
-        c.AddSequence(sequences[cluster.SeqIndex(seq_i)]);
-      }
-      if (cluster.IsFullyMerged()) {
-        c.SetFullyMerged();
-      }
-      clusters_.push_back(std::move(c));
-    }    
+ClusterSet::ClusterSet(MarshalledClusterSetView& marshalled_set,
+                       const vector<size_t>& set_offsets, int start_index,
+                       int end_index, const std::vector<Sequence>& sequences) {
+  MarshalledClusterView cluster;
+  for (int i = start_index; i <= end_index; i++) {
+    marshalled_set.ClusterAtOffset(&cluster, set_offsets[i]);
+    Cluster c(sequences[cluster.SeqIndex(0)]);
+    uint32_t num_seqs = cluster.NumSeqs();
+    for (size_t seq_i = 1; seq_i < num_seqs; seq_i++) {
+      c.AddSequence(sequences[cluster.SeqIndex(seq_i)]);
+    }
+    if (cluster.IsFullyMerged()) {
+      c.SetFullyMerged();
+    }
+    clusters_.push_back(std::move(c));
+  }
 }
 
 ClusterSet::ClusterSet(MarshalledClusterSetView& marshalled_set,
@@ -463,7 +468,6 @@ ClusterSet ClusterSet::MergeCluster(Cluster& c_other, ProteinAligner* aligner,
     }
     new_cluster_set.clusters_.push_back(std::move(c_standin));
   }
-
 
   return new_cluster_set;
 }

--- a/src/common/cluster_set.cc
+++ b/src/common/cluster_set.cc
@@ -73,6 +73,23 @@ ClusterSet::ClusterSet(MarshalledClusterSet& marshalled_set,
   }
 }
 
+ClusterSet::ClusterSet(MarshalledClusterSetView& marshalled_set, vector<size_t>& set_offsets, 
+  int start_index, int end_index, const std::vector<Sequence>& sequences) {
+    MarshalledClusterView cluster;
+    for (int i = start_index; i <= end_index; i++) {
+      marshalled_set.ClusterAtOffset(&cluster, set_offsets[i]);
+      Cluster c(sequences[cluster.SeqIndex(0)]);
+      uint32_t num_seqs = cluster.NumSeqs();
+      for (size_t seq_i = 1; seq_i < num_seqs; seq_i++) {
+        c.AddSequence(sequences[cluster.SeqIndex(seq_i)]);
+      }
+      if (cluster.IsFullyMerged()) {
+        c.SetFullyMerged();
+      }
+      clusters_.push_back(std::move(c));
+    }    
+}
+
 ClusterSet::ClusterSet(MarshalledClusterSetView& marshalled_set,
                        const std::vector<Sequence>& sequences) {
   // yeah its copied from above idc

--- a/src/common/cluster_set.cc
+++ b/src/common/cluster_set.cc
@@ -47,7 +47,7 @@ void ClusterSet::BuildMarshalledResponse(int id, RequestType type, MarshalledRes
     }
   }
 
-  char* data = buf.mutable_data() + sizeof(int);
+  char* data = buf.mutable_data() + sizeof(ResponseHeader);
   ClusterSetHeader* hp = reinterpret_cast<ClusterSetHeader*>(data);
   hp->num_clusters = clusters_.size();
   // hand the buf pointer to the message
@@ -90,7 +90,7 @@ void ClusterSet::BuildMarshalledResponse(int id, int start_index,
       }
   }
 
-  char* data = buf.mutable_data() + sizeof(int);
+  char* data = buf.mutable_data() + sizeof(ResponseHeader) + 3*sizeof(int);
   ClusterSetHeader* hp = reinterpret_cast<ClusterSetHeader*>(data);
   hp->num_clusters = clusters_.size();
   // hand the buf pointer to the message

--- a/src/common/cluster_set.h
+++ b/src/common/cluster_set.h
@@ -31,6 +31,9 @@ class ClusterSet {
   ClusterSet(MarshalledClusterSetView& marshalled_set,
              const std::vector<Sequence>& sequences);
 
+  ClusterSet(MarshalledClusterSetView& marshalled_set, std::vector<size_t>& set_offsets, 
+    int start_index, int end_index, const std::vector<Sequence>& sequences);
+
   void BuildMarshalledResponse(int id, MarshalledResponse* response);
 
   // void ConstructProto(cmproto::ClusterSet* set_proto);

--- a/src/common/cluster_set.h
+++ b/src/common/cluster_set.h
@@ -34,7 +34,10 @@ class ClusterSet {
   ClusterSet(MarshalledClusterSetView& marshalled_set, std::vector<size_t>& set_offsets, 
     int start_index, int end_index, const std::vector<Sequence>& sequences);
 
-  void BuildMarshalledResponse(int id, MarshalledResponse* response);
+  void BuildMarshalledResponse(int id, RequestType type, MarshalledResponse* response);
+
+  void BuildMarshalledResponse(int id, int start_index, int end_index, 
+    int cluster_index, MarshalledResponse* response);
 
   // void ConstructProto(cmproto::ClusterSet* set_proto);
 

--- a/src/common/cluster_set.h
+++ b/src/common/cluster_set.h
@@ -31,13 +31,15 @@ class ClusterSet {
   ClusterSet(MarshalledClusterSetView& marshalled_set,
              const std::vector<Sequence>& sequences);
 
-  ClusterSet(MarshalledClusterSetView& marshalled_set, std::vector<size_t>& set_offsets, 
-    int start_index, int end_index, const std::vector<Sequence>& sequences);
+  ClusterSet(MarshalledClusterSetView& marshalled_set,
+             const std::vector<size_t>& set_offsets, int start_index,
+             int end_index, const std::vector<Sequence>& sequences);
 
-  void BuildMarshalledResponse(int id, RequestType type, MarshalledResponse* response);
+  void BuildMarshalledResponse(int id, RequestType type,
+                               MarshalledResponse* response);
 
-  void BuildMarshalledResponse(int id, int start_index, int end_index, 
-    int cluster_index, MarshalledResponse* response);
+  void BuildMarshalledResponse(int id, int start_index, int end_index,
+                               int cluster_index, MarshalledResponse* response);
 
   // void ConstructProto(cmproto::ClusterSet* set_proto);
 
@@ -57,7 +59,7 @@ class ClusterSet {
   // merge two cluster sets by building a new one, in parallel (uses std::async)
   ClusterSet MergeClustersParallel(ClusterSet& other, MergeExecutor* executor);
 
-  //Add by akash
+  // Add by akash
   void AddCluster(Cluster& c) { clusters_.push_back(std::move(c)); }
 
   // merge `this` with `cluster`, called from parallel merge executor
@@ -70,7 +72,8 @@ class ClusterSet {
   void RemoveDuplicates();
 
   void DebugDump() const;
-  void DumpJson(const std::string& filename, std::vector <std::string>& dataset_file_names) const;
+  void DumpJson(const std::string& filename,
+                std::vector<std::string>& dataset_file_names) const;
 
   void MarshalToBuffer(agd::Buffer* buf);
 

--- a/src/comms/requests.h
+++ b/src/comms/requests.h
@@ -277,6 +277,7 @@ struct MarshalledRequest {
     PartialRequestHeader h;
     h.id = id;
     h.type = RequestType::SubLargePartial;
+    buf.reserve(sizeof(PartialRequestHeader) + sizeof(int)*3 + cluster.TotalSize());
     buf.AppendBuffer(reinterpret_cast<char*>(&h), sizeof(PartialRequestHeader));
     buf.AppendBuffer(reinterpret_cast<char*>(&start_index), sizeof(int));
     buf.AppendBuffer(reinterpret_cast<char*>(&end_index), sizeof(int));

--- a/src/comms/requests.h
+++ b/src/comms/requests.h
@@ -108,7 +108,7 @@ struct MarshalledClusterSetView {
     }
   } 
 
-  // relies on user to make sure offset is correct (within bounds)
+  // no check on offset, assumed correct
   bool ClusterAtOffset(MarshalledClusterView* cluster, size_t offset) {
     const char* cluster_ptr = data + offset;
     *cluster = MarshalledClusterView(cluster_ptr);
@@ -182,7 +182,7 @@ struct MarshalledClusterSet {
   MarshalledClusterSet(MarshalledResponse& response)
       : buf(agd::Buffer(response.msg.size() - sizeof(uint32_t), 128)) {
     // a response buffer is an int id and a marshalled clusterset
-    char* data = reinterpret_cast<char*>(response.msg.data());
+    const char* data = reinterpret_cast<const char*>(response.msg.data());
     data += sizeof(ResponseHeader);
     auto data_size = response.msg.size() - sizeof(ResponseHeader);
     // buf.reserve(data_size);

--- a/src/comms/requests.h
+++ b/src/comms/requests.h
@@ -204,10 +204,12 @@ struct MarshalledClusterSet {
       num_clusters++;  
     }
 
-    std::sort(clusters.begin(), clusters.end(), 
-      [](std::pair<uint32_t, size_t> p1, std::pair<uint32_t, size_t> p2) {
-        return p1.first >= p2.first;
-    });
+    // std::sort(clusters.begin(), clusters.end(), 
+    //   [](const std::pair<uint32_t, size_t>& p1, const std::pair<uint32_t, size_t>& p2) {
+    //     return p1.first >= p2.first;
+    // });
+
+    std::sort(clusters.begin(), clusters.end(), std::greater<std::pair<uint32_t, size_t>>());
     
     agd::Buffer new_buf(buf.size());
     const char* data = buf.data();

--- a/src/comms/requests.h
+++ b/src/comms/requests.h
@@ -153,7 +153,7 @@ struct MarshalledResponse {
       int start_index = *reinterpret_cast<const int*>(data);
       int end_index = *reinterpret_cast<const int*>(data + sizeof(int));
       int cluster_index = *reinterpret_cast<const int*>(data + 2*sizeof(int));
-      indexes = {start_index, end_index, cluster_index};
+      indexes = std::make_tuple(start_index, end_index, cluster_index);
     }
     return indexes;
   }

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -235,6 +235,23 @@ agd::Status Controller::Run(const Params& params,
     cout << "Work queue thread ending. Total sent: " << total_sent << "\n";
   });
 
+  std::thread queue_measure_thread = std::thread([this](){
+      // get timestamp, queue size
+      //cout << "queue measure thread starting ...\n";
+      while(run_) {
+        time_t result = std::time(nullptr);
+        //timestamps_.push_back(static_cast<long int>(result));
+        //queue_sizes_.push_back(work_queue_->size());
+        std::cout << static_cast<long int>(result) << ": " << response_queue_->size() << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        // if (queue_sizes_.size() >= 1000000) {
+        //  break;  // dont run forever ...
+        // }
+      }
+      cout << "queue measure thread finished\n";
+    }
+  );
+
   set_request_thread_ = thread([this]() {
     // receive requests from worker and send them cluster sets
 
@@ -410,24 +427,6 @@ agd::Status Controller::Run(const Params& params,
   for (size_t i = 0; i < params.num_threads; i++) {
     worker_threads_.push_back(std::thread(worker_func));
   }
-
-  queue_measure_thread_ = std::thread([this](){
-      // get timestamp, queue size
-      //cout << "queue measure thread starting ...\n";
-      while(run_) {
-        time_t result = std::time(nullptr);
-        //timestamps_.push_back(static_cast<long int>(result));
-        //queue_sizes_.push_back(work_queue_->size());
-        cout << static_cast<long int>(result) << ": " << response_queue->size() << std::endl;
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        // if (queue_sizes_.size() >= 1000000) {
-        //  break;  // dont run forever ...
-        // }
-      }
-      cout << "queue measure thread finished\n";
-    }
-  );
-
 
   cout << "loading to marshalled sets\n";
   // dump all sequences in single cluster sets into the queue

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -44,7 +44,7 @@ agd::Status Controller::Run(const Params& params,
                             std::vector<std::unique_ptr<Dataset>>& datasets) {
   checkpoint_timer_ = timestamp();
   std::atomic_int_fast32_t outstanding_requests{0};
-
+  cout << "Num seqs threshold: " << params.nseqs_threshold << "\n";
   // index all sequences
   agd::Status s = Status::OK();
   const char* data;

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -355,6 +355,7 @@ agd::Status Controller::Run(const Params& params,
 
       if(type == RequestType::Batch) {
         MarshalledClusterSet new_set(response);
+        //new_set.SortSet();
         sets_to_merge_queue_->push(std::move(new_set));
         outstanding_requests--;
       
@@ -385,7 +386,7 @@ agd::Status Controller::Run(const Params& params,
           
           MarshalledClusterSet set;
           partial_item->partial_set.BuildMarshalledSet(&set);
-          
+          //set.SortSet();
           {
             if (outstanding_merges_ == 1) {
               cout << "last request complete, 1 merge left, time: "
@@ -557,6 +558,7 @@ agd::Status Controller::Run(const Params& params,
       num_chunks += 1;
       
       item.num_expected = num_chunks * sets[0].NumClusters();
+      cout << "Num expected: " << item.num_expected << " " << "Set2 size: " << sets[0].NumClusters() << "\n"; 
       // Reset calls done in function
       item.partial_set.Init(sets[0], sets[1]);
 
@@ -570,6 +572,17 @@ agd::Status Controller::Run(const Params& params,
       uint32_t total_cluster = sets[0].NumClusters();
       uint32_t cluster_index = 0; 
       
+      if(outstanding_merges_ == 0)  {
+        sets[1].Reset();
+        MarshalledClusterView cluster1;
+        std::ofstream outfile;
+        outfile.open("num_seqs.csv", std::ios::out);
+        while(sets[1].NextCluster(&cluster1)) {
+          outfile << cluster1.NumSeqs() << "\n";
+        }
+        outfile.close();
+      }
+
       sets[0].Reset();
       while(sets[0].NextCluster(&cluster))  {
         MarshalledClusterView cluster2;

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -402,8 +402,16 @@ agd::Status Controller::Run(const Params& params,
         if (partial_item->num_expected - 1 == val) {
           
           MarshalledClusterSet set;
+          if (outstanding_merges_ == 0) {
+            cout << "building final marshalled set, time: "
+                << static_cast<long int>(std::time(0)) << "\n";
+          }
           partial_item->partial_set.BuildMarshalledSet(&set);
           set.SortSet();
+          if (outstanding_merges_ == 0) {
+            cout << "done, time: "
+                << static_cast<long int>(std::time(0)) << "\n";
+          }
           {
             if (outstanding_merges_ == 1) {
               cout << "last request complete, 1 merge left, time: "

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -524,7 +524,7 @@ agd::Status Controller::Run(const Params& params,
       outstanding_requests++;
 
     } else {
-      uint32_t threshold = 1000;
+      //uint32_t threshold = 5000;
       //Based on number of sequences, split cluster sets
       outstanding_merges_--;
       PartialMergeItem item;
@@ -542,7 +542,7 @@ agd::Status Controller::Run(const Params& params,
       sets[1].Reset();
       while(sets[1].NextCluster(&cluster)) {
         num_seqs += cluster.NumSeqs();
-        if(num_seqs > threshold)  {
+        if(num_seqs > params.nseqs_threshold)  {
           if(ci == pi+1)  {
             pi = ci;
             num_seqs = 0;
@@ -579,7 +579,7 @@ agd::Status Controller::Run(const Params& params,
         pi = -1, ci = 0; //ci: current index, pi: previous index
         while(sets[1].NextCluster(&cluster2)) {
           num_seqs += cluster2.NumSeqs();
-          if(num_seqs > threshold)  {
+          if(num_seqs > params.nseqs_threshold)  {
             MarshalledRequest request;
             if(ci == pi+1)  {
               request.CreateSubLargePartialRequest(outstanding_merges_, cluster, pi+1, ci, cluster_index);

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -146,13 +146,13 @@ agd::Status Controller::Run(const Params& params,
 
   // zmq_recv_socket_->setsockopt(ZMQ_RCVHWM, 2);
   // TODO make sendhwm a param
-  zmq_send_socket_->setsockopt(ZMQ_SNDHWM, 3);
-  int val = zmq_send_socket_->getsockopt<int>(ZMQ_SNDHWM);
-  cout << "snd hwm value is " << val << " \n";
+  // zmq_send_socket_->setsockopt(ZMQ_SNDHWM, 3);
+  // int val = zmq_send_socket_->getsockopt<int>(ZMQ_SNDHWM);
+  // cout << "snd hwm value is " << val << " \n";
 
   // waits for timeout time and then returns with EAGAIN
   zmq_set_request_socket_->setsockopt(ZMQ_RCVTIMEO, 1000);
-  val = zmq_set_request_socket_->getsockopt<int>(ZMQ_RCVTIMEO);
+  int val = zmq_set_request_socket_->getsockopt<int>(ZMQ_RCVTIMEO);
   cout << "recv timeout set to " << val << " ms \n";
 
   try {

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -565,28 +565,31 @@ agd::Status Controller::Run(const Params& params,
       MarshalledClusterView cluster;
       // cout << "pushing id " << outstanding_merges_ << "\n";
       uint32_t total_cluster = sets[0].NumClusters();
-      uint32_t i = 0;
+      uint32_t cluster_index = 0;
 
       while (sets[0].NextCluster(&cluster)) {
-        i++;
         MarshalledRequest request;
         if (isLarge) {
           request.CreateLargePartialRequest(outstanding_merges_, cluster);
         } else {
           request.CreatePartialRequest(outstanding_merges_, cluster, sets[1]);
         }
-        // cout << "pushing partial request with " <<
-        // partial_request->set().clusters_size() << " clusters in set and ID: "
-        // << request.id() << "\n";
-        // cout << "Pushing partial merge request " << "\n";
+
+        //create a subLargePartialRequest
+        MarshalledRequest request_test;
+        request_test.CreateSubLargePartialRequest(outstanding_merges_, cluster, 
+         10, 15, cluster_index);
+        
         request_queue_->push(std::move(request));
+        request_queue_->push(std::move(request_test));
+        cluster_index++;
       }
       outstanding_requests++;
       if (outstanding_merges_ == 1) {
         cout << "last request sent, 1 merge left, time: "
              << static_cast<long int>(std::time(0)) << "\n";
       }
-      assert(i == total_cluster);
+      assert(cluster_index == total_cluster);
       // set partial outstanding
       // outstanding_partial_ = true;
     }

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -235,22 +235,22 @@ agd::Status Controller::Run(const Params& params,
     cout << "Work queue thread ending. Total sent: " << total_sent << "\n";
   });
 
-  std::thread queue_measure_thread = std::thread([this](){
-      // get timestamp, queue size
-      //cout << "queue measure thread starting ...\n";
-      while(run_) {
-        time_t result = std::time(nullptr);
-        //timestamps_.push_back(static_cast<long int>(result));
-        //queue_sizes_.push_back(work_queue_->size());
-        std::cout << static_cast<long int>(result) << ": " << response_queue_->size() << std::endl;
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        // if (queue_sizes_.size() >= 1000000) {
-        //  break;  // dont run forever ...
-        // }
-      }
-      cout << "queue measure thread finished\n";
-    }
-  );
+  // std::thread queue_measure_thread = std::thread([this](){
+  //     // get timestamp, queue size
+  //     //cout << "queue measure thread starting ...\n";
+  //     while(run_) {
+  //       time_t result = std::time(nullptr);
+  //       //timestamps_.push_back(static_cast<long int>(result));
+  //       //queue_sizes_.push_back(work_queue_->size());
+  //       std::cout << static_cast<long int>(result) << ": " << response_queue_->size() << std::endl;
+  //       std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  //       // if (queue_sizes_.size() >= 1000000) {
+  //       //  break;  // dont run forever ...
+  //       // }
+  //     }
+  //     cout << "queue measure thread finished\n";
+  //   }
+  // );
 
   set_request_thread_ = thread([this]() {
     // receive requests from worker and send them cluster sets
@@ -575,10 +575,8 @@ agd::Status Controller::Run(const Params& params,
       num_chunks += 1;
       
       item.num_expected = num_chunks * sets[0].NumClusters();
-      cout << "Num expected: " << item.num_expected << " " << "Set2 size: " << sets[0].NumClusters() << "\n"; 
       // Reset calls done in function
       item.partial_set.Init(sets[0], sets[1]);
-
       item.marshalled_set_buf.AppendBuffer(sets[1].buf.data(), sets[1].buf.size());
 
       {
@@ -588,17 +586,6 @@ agd::Status Controller::Run(const Params& params,
 
       uint32_t total_cluster = sets[0].NumClusters();
       uint32_t cluster_index = 0; 
-      
-      if(outstanding_merges_ == 0)  {
-        sets[1].Reset();
-        MarshalledClusterView cluster1;
-        std::ofstream outfile;
-        outfile.open("num_seqs.csv", std::ios::out);
-        while(sets[1].NextCluster(&cluster1)) {
-          outfile << cluster1.NumSeqs() << "\n";
-        }
-        outfile.close();
-      }
 
       sets[0].Reset();
       while(sets[0].NextCluster(&cluster))  {

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -403,7 +403,7 @@ agd::Status Controller::Run(const Params& params,
           
           MarshalledClusterSet set;
           partial_item->partial_set.BuildMarshalledSet(&set);
-          //set.SortSet();
+          set.SortSet();
           {
             if (outstanding_merges_ == 1) {
               cout << "last request complete, 1 merge left, time: "

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -575,6 +575,7 @@ agd::Status Controller::Run(const Params& params,
       num_chunks += 1;
       
       item.num_expected = num_chunks * sets[0].NumClusters();
+      std::cout << "Num expected: " << item.num_expected << " " << " set1 clusters: " << sets[0].NumClusters() << "\n";
       // Reset calls done in function
       item.partial_set.Init(sets[0], sets[1]);
       item.marshalled_set_buf.AppendBuffer(sets[1].buf.data(), sets[1].buf.size());

--- a/src/dist/controller.cc
+++ b/src/dist/controller.cc
@@ -411,6 +411,24 @@ agd::Status Controller::Run(const Params& params,
     worker_threads_.push_back(std::thread(worker_func));
   }
 
+  queue_measure_thread_ = std::thread([this](){
+      // get timestamp, queue size
+      //cout << "queue measure thread starting ...\n";
+      while(run_) {
+        time_t result = std::time(nullptr);
+        //timestamps_.push_back(static_cast<long int>(result));
+        //queue_sizes_.push_back(work_queue_->size());
+        cout << static_cast<long int>(result) << ": " << response_queue->size() << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        // if (queue_sizes_.size() >= 1000000) {
+        //  break;  // dont run forever ...
+        // }
+      }
+      cout << "queue measure thread finished\n";
+    }
+  );
+
+
   cout << "loading to marshalled sets\n";
   // dump all sequences in single cluster sets into the queue
   // for now assumes all of this will fit in memory

--- a/src/dist/controller.h
+++ b/src/dist/controller.h
@@ -29,6 +29,7 @@ class Controller {
     int set_request_port;
     absl::string_view data_dir_path;
     uint32_t batch_size;
+    uint32_t nseqs_threshold;
     uint32_t dup_removal_thresh;
     bool exclude_allall;
     int dataset_limit;

--- a/src/dist/controller.h
+++ b/src/dist/controller.h
@@ -118,4 +118,6 @@ class Controller {
   uint32_t outstanding_merges_ = 0;
   volatile bool outstanding_partial_ = false;
   absl::Mutex mu_;  // for partial_merge_map_
+
+  //absl::Mutex mu1_;
 };

--- a/src/dist/controller.h
+++ b/src/dist/controller.h
@@ -74,7 +74,6 @@ class Controller {
 
   // thread to send partial merge sets
   std::thread set_request_thread_;
-  
   std::vector<Sequence> sequences_;  // abs indexable sequences
 
   long int checkpoint_timer_;
@@ -118,6 +117,4 @@ class Controller {
   uint32_t outstanding_merges_ = 0;
   volatile bool outstanding_partial_ = false;
   absl::Mutex mu_;  // for partial_merge_map_
-
-  //absl::Mutex mu1_;
 };

--- a/src/dist/controller.h
+++ b/src/dist/controller.h
@@ -74,7 +74,7 @@ class Controller {
 
   // thread to send partial merge sets
   std::thread set_request_thread_;
-
+  
   std::vector<Sequence> sequences_;  // abs indexable sequences
 
   long int checkpoint_timer_;

--- a/src/dist/dist_cluster.cc
+++ b/src/dist/dist_cluster.cc
@@ -162,7 +162,7 @@ int main(int argc, char* argv[]) {
 
   uint32_t nseqs_threshold = 100000;
   if (nseqs_threshold_arg)  {
-    nseqs_threshold = nseqs_threshold_arg;
+    nseqs_threshold = args::get(nseqs_threshold_arg);
   }
 
   json server_config_json;

--- a/src/dist/dist_cluster.cc
+++ b/src/dist/dist_cluster.cc
@@ -70,6 +70,9 @@ int main(int argc, char* argv[]) {
   args::ValueFlag<unsigned int> queue_depth_arg(
       parser, "queue_depth", "Depth of the local work and response queue.",
       {'q', "queue_depth"});
+  args::ValueFlag<unsigned int> nseqs_threshold_arg(
+      parser, "no. of seqs threshold", "Max number of total sequences in a cluster chunk.",
+      {'n', "nseqs_threshold"});
   args::ValueFlag<unsigned int> batch_size_arg(
       parser, "batch size",
       "How many small clusters should be batched together.",
@@ -155,6 +158,11 @@ int main(int argc, char* argv[]) {
   uint32_t dup_removal_threshold = UINT_MAX;
   if (dup_removal_threshold_arg) {
     dup_removal_threshold = args::get(dup_removal_threshold_arg);
+  }
+
+  uint32_t nseqs_threshold = 100000;
+  if (nseqs_threshold_arg)  {
+    nseqs_threshold = nseqs_threshold_arg;
   }
 
   json server_config_json;
@@ -334,6 +342,7 @@ int main(int argc, char* argv[]) {
     Controller controller;
     Controller::Params params;
     params.batch_size = batch_size;
+    params.nseqs_threshold = nseqs_threshold;
     params.controller_ip = controller_ip;
     params.data_dir_path = json_dir_path;
     params.num_threads = threads;

--- a/src/dist/dist_cluster.cc
+++ b/src/dist/dist_cluster.cc
@@ -160,7 +160,7 @@ int main(int argc, char* argv[]) {
     dup_removal_threshold = args::get(dup_removal_threshold_arg);
   }
 
-  uint32_t nseqs_threshold = 100000;
+  uint32_t nseqs_threshold = UINT_MAX;
   if (nseqs_threshold_arg)  {
     nseqs_threshold = args::get(nseqs_threshold_arg);
   }

--- a/src/dist/dist_cluster.cc
+++ b/src/dist/dist_cluster.cc
@@ -71,7 +71,8 @@ int main(int argc, char* argv[]) {
       parser, "queue_depth", "Depth of the local work and response queue.",
       {'q', "queue_depth"});
   args::ValueFlag<unsigned int> nseqs_threshold_arg(
-      parser, "no. of seqs threshold", "Max number of total sequences in a cluster chunk.",
+      parser, "no. of seqs threshold",
+      "Max number of total sequences in a cluster chunk.",
       {'n', "nseqs_threshold"});
   args::ValueFlag<unsigned int> batch_size_arg(
       parser, "batch size",
@@ -161,7 +162,7 @@ int main(int argc, char* argv[]) {
   }
 
   uint32_t nseqs_threshold = UINT_MAX;
-  if (nseqs_threshold_arg)  {
+  if (nseqs_threshold_arg) {
     nseqs_threshold = args::get(nseqs_threshold_arg);
   }
 

--- a/src/dist/partial_merge.cc
+++ b/src/dist/partial_merge.cc
@@ -16,10 +16,25 @@ void PartialMergeSet::Init(MarshalledClusterSet& set1, MarshalledClusterSet& set
 }
 
 void PartialMergeSet::BuildMarshalledSet(MarshalledClusterSet* set) {
+
+  size_t buf_size = sizeof(ClusterSetHeader);
+  for (const auto& c : clusters_set1_) {
+    if (c.IsFullyMerged()) {
+      continue;
+    }
+    buf_size += sizeof(ClusterHeader) + sizeof(uint32_t)*c.SeqIndexes().size();
+  }
+  for (const auto& c : clusters_set2_) {
+    if (c.IsFullyMerged()) {
+      continue;
+    }
+    buf_size += sizeof(ClusterHeader) + sizeof(uint32_t)*c.SeqIndexes().size();
+  }
+  
   ClusterSetHeader h;
   h.num_clusters = 0;  // set after once we know the value
   set->buf.reset();
-  set->buf.reserve(512);
+  set->buf.reserve(buf_size);
   set->buf.AppendBuffer(reinterpret_cast<char*>(&h), sizeof(ClusterSetHeader));
 
   uint32_t total_not_merged = 0;

--- a/src/dist/partial_merge.cc
+++ b/src/dist/partial_merge.cc
@@ -47,22 +47,19 @@ void PartialMergeSet::BuildMarshalledSet(MarshalledClusterSet* set) {
     total_not_merged++;
 
     seq_set.clear();
+    seq_set.reserve(c.SeqIndexes().size() + c.NumNewSeqs());
+    for (auto s : c.SeqIndexes()) {
+      seq_set.insert(s);
+    }
     c.AddNewSeqs(&seq_set); // create a hash set to remove duplicates
 
     ClusterHeader ch;
     ch.fully_merged = false;
-    ch.num_seqs = c.NumOrigSeqs() + seq_set.size();
+    ch.num_seqs = seq_set.size();
     set->buf.AppendBuffer(reinterpret_cast<char*>(&ch), sizeof(ClusterHeader));
     auto r = c.Representative();
     set->buf.AppendBuffer(reinterpret_cast<char*>(&r), sizeof(uint32_t));
     int i = 1;
-
-    for (auto s : c.SeqIndexes()) {
-      if (s != r) {
-        i++;
-        set->buf.AppendBuffer(reinterpret_cast<char*>(&s), sizeof(uint32_t));
-      }
-    }
 
     for (auto s : seq_set) {
       if (s != r) {
@@ -70,7 +67,7 @@ void PartialMergeSet::BuildMarshalledSet(MarshalledClusterSet* set) {
         set->buf.AppendBuffer(reinterpret_cast<char*>(&s), sizeof(uint32_t));
       }
     }
-    assert(i == c.NumOrigSeqs() + seq_set.size());
+    assert(i == seq_set.size());
   }
 
   for (const auto& c : clusters_set2_) {
@@ -80,22 +77,19 @@ void PartialMergeSet::BuildMarshalledSet(MarshalledClusterSet* set) {
     total_not_merged++;
 
     seq_set.clear();
+    seq_set.reserve(c.SeqIndexes().size() + c.NumNewSeqs());
+    for (auto s : c.SeqIndexes()) {
+      seq_set.insert(s);
+    }
     c.AddNewSeqs(&seq_set); // create a hash set to remove duplicates
 
     ClusterHeader ch;
     ch.fully_merged = false;
-    ch.num_seqs = c.NumOrigSeqs() + seq_set.size();
+    ch.num_seqs = seq_set.size();
     set->buf.AppendBuffer(reinterpret_cast<char*>(&ch), sizeof(ClusterHeader));
     auto r = c.Representative();
     set->buf.AppendBuffer(reinterpret_cast<char*>(&r), sizeof(uint32_t)); 
     int i = 1;
-
-    for (auto s : c.SeqIndexes()) {
-      if (s != r) {
-        i++;
-        set->buf.AppendBuffer(reinterpret_cast<char*>(&s), sizeof(uint32_t));
-      }
-    }
 
     for (auto s : seq_set) {
       if (s != r) {
@@ -103,7 +97,7 @@ void PartialMergeSet::BuildMarshalledSet(MarshalledClusterSet* set) {
         set->buf.AppendBuffer(reinterpret_cast<char*>(&s), sizeof(uint32_t));
       }
     }
-    assert(i == c.NumOrigSeqs() + seq_set.size());
+    assert(i == seq_set.size());
   }
 
   char* data = set->buf.mutable_data();

--- a/src/dist/partial_merge.cc
+++ b/src/dist/partial_merge.cc
@@ -3,6 +3,8 @@
 
 void PartialMergeSet::Init(MarshalledClusterSet& set1, MarshalledClusterSet& set2) {
   MarshalledClusterView cluster;
+  set1.Reset();
+  set2.Reset();
   while (set1.NextCluster(&cluster)) {
     IndexedCluster ic(cluster);
     clusters_set1_.push_back(std::move(ic));
@@ -11,6 +13,7 @@ void PartialMergeSet::Init(MarshalledClusterSet& set1, MarshalledClusterSet& set
     IndexedCluster ic(cluster);
     clusters_set2_.push_back(std::move(ic));
   }
+  //std::cout << "Set sizes: " << clusters_set1_.size() << " " << clusters_set2_.size() << '\n';
 }
 
 void PartialMergeSet::BuildMarshalledSet(MarshalledClusterSet* set) {
@@ -88,6 +91,7 @@ void PartialMergeSet::BuildMarshalledSet(MarshalledClusterSet* set) {
 
 void PartialMergeSet::MergeClusterSet(MarshalledClusterSetView set, int start_index, 
   int end_index, int cluster_index) {
+  //std::cout << "Merging cluster set " << clusters_set2_.size() << "\n";
   MarshalledClusterView cluster;
   uint32_t clusters_in_chunk = end_index - start_index + 1;
   assert(set.NumClusters() >= clusters_in_chunk);
@@ -103,8 +107,11 @@ void PartialMergeSet::MergeClusterSet(MarshalledClusterSetView set, int start_in
     if (cluster.IsFullyMerged()) {
       clusters_set2_[i].SetFullyMerged();
     } else {
+      //std::cout << "Running for loop " << cluster.NumSeqs() << "\n";
       // cluster has only diffs, push them directly
       for (uint32_t x = 0; x < cluster.NumSeqs(); x++) {
+        //std::cout << "For loop: " <<  x  << " " << cluster.NumSeqs() << "\n";
+        //std::cout << x << " " << cluster.SeqIndex(x) << "\n";
         clusters_set2_[i].Insert(cluster.SeqIndex(x));
       }
     }

--- a/src/dist/partial_merge.cc
+++ b/src/dist/partial_merge.cc
@@ -13,7 +13,6 @@ void PartialMergeSet::Init(MarshalledClusterSet& set1, MarshalledClusterSet& set
     IndexedCluster ic(cluster);
     clusters_set2_.push_back(std::move(ic));
   }
-  //std::cout << "Set sizes: " << clusters_set1_.size() << " " << clusters_set2_.size() << '\n';
 }
 
 void PartialMergeSet::BuildMarshalledSet(MarshalledClusterSet* set) {

--- a/src/dist/partial_merge.cc
+++ b/src/dist/partial_merge.cc
@@ -52,7 +52,7 @@ void PartialMergeSet::BuildMarshalledSet(MarshalledClusterSet* set) {
     assert(i == seq_set.size());
   }
 
-  for (const auto& c : clusters_set2) {
+  for (const auto& c : clusters_set2_) {
     if (c.IsFullyMerged()) {
       continue;
     }
@@ -91,12 +91,12 @@ void PartialMergeSet::MergeClusterSet(MarshalledClusterSetView set, int start_in
   MarshalledClusterView cluster;
   uint32_t clusters_in_chunk = end_index - start_index + 1;
   assert(set.NumClusters() >= clusters_in_chunk);
-  for (uint32_t i = start_index; i <= end_index; i++) {
+  for (int i = start_index; i <= end_index; i++) {
     // auto cluster = set.Cluster(i);
     if (!set.NextCluster(&cluster)) {
       std::cout << "error next cluster returned false? on index " << i
                 << " with clusters size " << set.NumClusters()
-                << " and orig clusters size " << clusters_.size() << "\n";
+                << " and orig clusters size " << clusters_in_chunk << "\n";
       exit(0);
     }
 

--- a/src/dist/partial_merge.h
+++ b/src/dist/partial_merge.h
@@ -120,20 +120,18 @@ class IndexedCluster {
 class PartialMergeSet {
  public:
   PartialMergeSet& operator=(PartialMergeSet&& other) {
-    clusters_ = std::move(other.clusters_);
-    new_clusters_ = std::move(other.new_clusters_);
+    clusters_set1_ = std::move(clusters_set1_);
+    clusters_set2_ = std::move(clusters_set2_);
     return *this;
   };
-  void MergeClusterSet(MarshalledClusterSetView set);
+  void MergeClusterSet(MarshalledClusterSetView set, int start_index, int end_index, int cluster_index);
   // build final set, not including fully merged clusters
   void BuildMarshalledSet(MarshalledClusterSet* set);
-  void Init(MarshalledClusterSet& set);
+  void Init(MarshalledClusterSet& set1, MarshalledClusterSet& set2);
   // void RemoveFullyMerged();
-  const std::vector<IndexedCluster>& Clusters() const { return clusters_; }
+  const std::vector<IndexedCluster>& Clusters() const { return clusters_set2_; }
 
  private:
-  std::vector<IndexedCluster> clusters_;  // does not change after construction
-  std::vector<MarshalledCluster> new_clusters_;
-  // lock to add new clusters
-  absl::Mutex mu_;
+  std::vector<IndexedCluster> clusters_set1_;
+  std::vector<IndexedCluster> clusters_set2_;  // does not change after construction
 };

--- a/src/dist/partial_merge.h
+++ b/src/dist/partial_merge.h
@@ -124,7 +124,8 @@ class PartialMergeSet {
     clusters_set2_ = std::move(other.clusters_set2_);
     return *this;
   };
-  void MergeClusterSet(MarshalledClusterSetView set, int start_index, int end_index, int cluster_index);
+  void MergeClusterSet(MarshalledClusterSetView set, int start_index,
+                       int end_index, int cluster_index);
   // build final set, not including fully merged clusters
   void BuildMarshalledSet(MarshalledClusterSet* set);
   void Init(MarshalledClusterSet& set1, MarshalledClusterSet& set2);
@@ -133,5 +134,6 @@ class PartialMergeSet {
 
  private:
   std::vector<IndexedCluster> clusters_set1_;
-  std::vector<IndexedCluster> clusters_set2_;  // does not change after construction
+  std::vector<IndexedCluster>
+      clusters_set2_;  // does not change after construction
 };

--- a/src/dist/partial_merge.h
+++ b/src/dist/partial_merge.h
@@ -120,8 +120,8 @@ class IndexedCluster {
 class PartialMergeSet {
  public:
   PartialMergeSet& operator=(PartialMergeSet&& other) {
-    clusters_set1_ = std::move(clusters_set1_);
-    clusters_set2_ = std::move(clusters_set2_);
+    clusters_set1_ = std::move(other.clusters_set1_);
+    clusters_set2_ = std::move(other.clusters_set2_);
     return *this;
   };
   void MergeClusterSet(MarshalledClusterSetView set, int start_index, int end_index, int cluster_index);

--- a/src/dist/worker.cc
+++ b/src/dist/worker.cc
@@ -472,15 +472,15 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
   queue_measure_thread_ = std::thread([this](){
       // get timestamp, queue size
       //cout << "queue measure thread starting ...\n";
-      while(worker_signal_) {
+      while(!worker_signal_) {
         time_t result = std::time(nullptr);
         //timestamps_.push_back(static_cast<long int>(result));
         //queue_sizes_.push_back(work_queue_->size());
         cout << static_cast<long int>(result) << ": " << work_queue_->size() << std::endl;
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        if (queue_sizes_.size() >= 1000000) {
-          break;  // dont run forever ...
-        }
+        // if (queue_sizes_.size() >= 1000000) {
+        //  break;  // dont run forever ...
+        // }
       }
       cout << "queue measure thread finished\n";
     }

--- a/src/dist/worker.cc
+++ b/src/dist/worker.cc
@@ -476,7 +476,7 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
         time_t result = std::time(nullptr);
         //timestamps_.push_back(static_cast<long int>(result));
         //queue_sizes_.push_back(work_queue_->size());
-        cout << static_cast<long int>(result) << ": " << work_queue_->size() << std::endl;
+        cout << static_cast<long int>(result) << ": " << work_queue_->size() << " " << response_queue_->size() << std::endl;
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         // if (queue_sizes_.size() >= 1000000) {
         //  break;  // dont run forever ...

--- a/src/dist/worker.cc
+++ b/src/dist/worker.cc
@@ -472,19 +472,16 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
   queue_measure_thread_ = std::thread([this](){
       // get timestamp, queue size
       //cout << "queue measure thread starting ...\n";
-      std::ofstream outfile;
-      outfile.open("queue_sizes.csv", std::ios::out);
       while(worker_signal_) {
         time_t result = std::time(nullptr);
         //timestamps_.push_back(static_cast<long int>(result));
         //queue_sizes_.push_back(work_queue_->size());
-        outfile << static_cast<long int>(result) << "," << work_queue_->size() << std::endl;
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        cout << static_cast<long int>(result) << ": " << work_queue_->size() << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         if (queue_sizes_.size() >= 1000000) {
           break;  // dont run forever ...
         }
       }
-      outfile.close();
       cout << "queue measure thread finished\n";
     }
   );

--- a/src/dist/worker.cc
+++ b/src/dist/worker.cc
@@ -298,7 +298,7 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
         MarshalledClusterSetView set(buf.data());
         std::vector<size_t> offsets;
         set.Offsets(offsets);
-        std::pair<agd::Buffer, std::vector<size_t>> set_and_offsets  = {std::move(buf), offsets};
+        std::pair<agd::Buffer, std::vector<size_t>> set_and_offsets  = {std::move(buf), std::move(offsets)};
 
         mu_.Lock();
         set_map_[id] = std::move(set_and_offsets);
@@ -369,7 +369,7 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
         id = request.ID();
         MarshalledClusterView cluster;
         request.IndexesAndCluster(&start_index, &end_index, &cluster_index, &cluster);
-        
+        //cout << "Request " << id << " " << start_index << " " << end_index << " " << cluster_index << "\n";
         // search in map
         mu_.Lock();
         auto it = set_map_.find(id);

--- a/src/dist/worker.cc
+++ b/src/dist/worker.cc
@@ -301,7 +301,7 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
         std::pair<agd::Buffer, std::vector<size_t>> set_and_offsets  = {std::move(buf), std::move(offsets)};
 
         mu_.Lock();
-        set_map_[id] = std::move(set_and_offsets);
+        set_map_.insert_or_assign(id, std::move(set_and_offsets));
         mu_.Unlock();
         cout << "Fetched set: [" << id << "]\n";
       } else {
@@ -386,10 +386,11 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
           assert(it != set_map_.end());
           // cout << "Worker thread --> [" << id << "] Received set.\n";
         }
-
+        mu_.Unlock();
+        
         MarshalledClusterSetView set(it->second.first.data());
         ClusterSet cs(set, it->second.second, start_index, end_index, sequences_);
-        mu_.Unlock();
+        
 
         Cluster c(cluster, sequences_);
 
@@ -466,8 +467,8 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
     cout << "Incomplete request queue thread ending.\n";
   });
 
-  // timestamps_.reserve(100000);
-  // queue_sizes_.reserve(100000);
+  /* timestamps_.reserve(100000);
+  queue_sizes_.reserve(100000);
 
   queue_measure_thread_ = std::thread([this](){
       // get timestamp, queue size
@@ -484,7 +485,7 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
       }
       cout << "queue measure thread finished\n";
     }
-  );
+  ); */ 
 
   while (!(*signal_num)) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10 * 100));

--- a/src/dist/worker.cc
+++ b/src/dist/worker.cc
@@ -231,9 +231,9 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
                                  incomplete_request_queue_address);
   }
 
-  zmq_recv_socket_->setsockopt(ZMQ_SNDHWM, 5);
-  int val = zmq_recv_socket_->getsockopt<int>(ZMQ_SNDHWM);
-  cout << "snd hwm value is " << val << " \n";
+  // zmq_recv_socket_->setsockopt(ZMQ_SNDHWM, 5);
+  // int val = zmq_recv_socket_->getsockopt<int>(ZMQ_SNDHWM);
+  // cout << "snd hwm value is " << val << " \n";
 
   work_queue_.reset(new ConcurrentQueue<zmq::message_t>(params.queue_depth));
   result_queue_.reset(

--- a/src/dist/worker.cc
+++ b/src/dist/worker.cc
@@ -476,7 +476,7 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
         time_t result = std::time(nullptr);
         //timestamps_.push_back(static_cast<long int>(result));
         //queue_sizes_.push_back(work_queue_->size());
-        cout << static_cast<long int>(result) << ": " << work_queue_->size() << " " << response_queue_->size() << std::endl;
+        cout << static_cast<long int>(result) << ": " << work_queue_->size() << " " << result_queue_->size() << std::endl;
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         // if (queue_sizes_.size() >= 1000000) {
         //  break;  // dont run forever ...

--- a/src/dist/worker.cc
+++ b/src/dist/worker.cc
@@ -466,24 +466,28 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
     cout << "Incomplete request queue thread ending.\n";
   });
 
-  /*timestamps_.reserve(100000);
-  queue_sizes_.reserve(100000);*/
+  // timestamps_.reserve(100000);
+  // queue_sizes_.reserve(100000);
 
-  // queue_measure_thread_ = std::thread([this](){
-  //     // get timestamp, queue size
-  //     //cout << "queue measure thread starting ...\n";
-  //     while(run_) {
-  //       time_t result = std::time(nullptr);
-  //       timestamps_.push_back(static_cast<long int>(result));
-  //       queue_sizes_.push_back(work_queue_->size());
-  //       std::this_thread::sleep_for(std::chrono::milliseconds(500));
-  //       if (queue_sizes_.size() >= 1000000) {
-  //         break;  // dont run forever ...
-  //       }
-  //     }
-  //     cout << "queue measure thread finished\n";
-  //   }
-  // );
+  queue_measure_thread_ = std::thread([this](){
+      // get timestamp, queue size
+      //cout << "queue measure thread starting ...\n";
+      std::ofstream outfile;
+      outfile.open("queue_sizes.csv", std::ios::out);
+      while(worker_signal_) {
+        time_t result = std::time(nullptr);
+        //timestamps_.push_back(static_cast<long int>(result));
+        //queue_sizes_.push_back(work_queue_->size());
+        outfile << static_cast<long int>(result) << "," << work_queue_->size() << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        if (queue_sizes_.size() >= 1000000) {
+          break;  // dont run forever ...
+        }
+      }
+      outfile.close();
+      cout << "queue measure thread finished\n";
+    }
+  );
 
   while (!(*signal_num)) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10 * 100));

--- a/src/dist/worker.cc
+++ b/src/dist/worker.cc
@@ -355,7 +355,7 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
 
         // final_set.ConstructProto(new_cs_proto);
         MarshalledResponse response;
-        final_set.BuildMarshalledResponse(request.ID(), &response);
+        final_set.BuildMarshalledResponse(request.ID(), request.Type(), &response);
         MarshalledClusterSetView view;
         view = response.Set();
         // cout << "final set has " << view.NumClusters() << " clusters.\n";
@@ -393,7 +393,7 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
         // cout << "cluster set now has " << new_cs.Size() << " clusters\n";
         assert(set.NumClusters() <= new_cs.Size());
         MarshalledResponse response;
-        new_cs.BuildMarshalledResponse(request.ID(), &response);
+        new_cs.BuildMarshalledResponse(request.ID(), request.Type(), &response);
         assert(response.Set().NumClusters() == new_cs.Size());
         result_queue_->push(std::move(response));
 
@@ -442,7 +442,7 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
         // cout << "cluster set now has " << new_cs.Size() << " clusters\n";
         assert(set.NumClusters() <= new_cs.Size());
         MarshalledResponse response;
-        new_cs.BuildMarshalledResponse(request.ID(), &response);
+        new_cs.BuildMarshalledResponse(request.ID(), request.Type(), &response);
         assert(response.Set().NumClusters() == new_cs.Size());
         result_queue_->push(std::move(response));
 
@@ -492,7 +492,7 @@ agd::Status Worker::Run(const Params& params, const Parameters& aligner_params,
         
         //this stuff needs some change, we need to a way to know what response it is
         MarshalledResponse response;
-        new_cs.BuildMarshalledResponse(request.ID(), &response);
+        new_cs.BuildMarshalledResponse(request.ID(), start_index, end_index, cluster_index, &response);
         assert(response.Set().NumClusters() == new_cs.Size());
         result_queue_->push(std::move(response));
 

--- a/src/dist/worker.h
+++ b/src/dist/worker.h
@@ -66,7 +66,7 @@ class Worker {
   bool irqt_signal_ = false;
 
   // cache for partial merge sets, buf is the buf of MarshalledClusterSet
-  std::unordered_map<int, agd::Buffer> set_map_;
+  std::unordered_map<int, std::pair<agd::Buffer, std::vector<size_t>>> set_map_;
   absl::Mutex mu_;  // for locking set_map_
 
   // queue to hold set requests

--- a/src/dist/worker.h
+++ b/src/dist/worker.h
@@ -9,6 +9,7 @@
 #include "src/common/sequence.h"
 #include "src/comms/requests.h"
 #include "src/dataset/dataset.h"
+#include "absl/container/node_hash_map.h"
 #include "zmq.hpp"
 
 // interface to manage local worker
@@ -66,7 +67,7 @@ class Worker {
   bool irqt_signal_ = false;
 
   // cache for partial merge sets, buf is the buf of MarshalledClusterSet
-  std::unordered_map<int, std::pair<agd::Buffer, std::vector<size_t>>> set_map_;
+  absl::node_hash_map<int, std::pair<agd::Buffer, std::vector<size_t>>> set_map_;
   absl::Mutex mu_;  // for locking set_map_
 
   // queue to hold set requests

--- a/src/dist/worker.h
+++ b/src/dist/worker.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <thread>
+#include "absl/container/node_hash_map.h"
 #include "src/agd/status.h"
 #include "src/common/concurrent_queue.h"
 #include "src/common/multi_notification.h"
@@ -9,7 +10,6 @@
 #include "src/common/sequence.h"
 #include "src/comms/requests.h"
 #include "src/dataset/dataset.h"
-#include "absl/container/node_hash_map.h"
 #include "zmq.hpp"
 
 // interface to manage local worker
@@ -67,7 +67,8 @@ class Worker {
   bool irqt_signal_ = false;
 
   // cache for partial merge sets, buf is the buf of MarshalledClusterSet
-  absl::node_hash_map<int, std::pair<agd::Buffer, std::vector<size_t>>> set_map_;
+  absl::node_hash_map<int, std::pair<agd::Buffer, std::vector<size_t>>>
+      set_map_;
   absl::Mutex mu_;  // for locking set_map_
 
   // queue to hold set requests

--- a/tools/cpu_record.py
+++ b/tools/cpu_record.py
@@ -7,7 +7,12 @@ pidstat_cmd = ["pidstat", "-hHIrdu", "-p", "pid_list", "1" ]
 sed_cmd = ["sed", r'1d;/^[#]/{{4,$d}};/^[#]/s/^[#][ ]*//;/^$/d;s/^[ ]*//;s/[ ]\+/,/g']
 
 #proc = subprocess.Popen(["./bazel-bin/src/dist/dist_cluster", "-i", "bacteria_datasets.json"]) 
-proc = subprocess.Popen(["./bazel-bin/src/clustermerge", "-c", "48", "-m", "48", "-t", "48", "-x", "-i", "bacteria_datasets.json"]) 
+# proc = subprocess.Popen(["./bazel-bin/src/clustermerge", 
+#     "-c", "48", "-m", "48", "-t", 
+#     "48", "-x", "-i", 
+#     "bacteria_datasets.json"]) 
+proc = subprocess.Popen(["./bazel-bin/src/dist/dist_cluster",
+    "-i", "/scratch/proteomes/bacteria_one.json", "-s", "../test_config.json"])
 #proc = subprocess.Popen(["./bazel-bin/src/clustermerge", "-c", "48", "-m", "48", "-t", "48", "-i", "four_datasets.json"]) 
 
 print("the pid is {}".format(proc.pid))


### PR DESCRIPTION
Splits a partial merge into further smaller dynamically sized chunks of work items. 

Specify the number of sequences threshold as `-n <value>`.